### PR TITLE
Add ignore_headers field to bazelifyrc

### DIFF
--- a/bazelifyrc/bazelifyrc.proto
+++ b/bazelifyrc/bazelifyrc.proto
@@ -16,4 +16,7 @@ message Configuration {
   // dependencies. This is useful for excluding things like the examples
   // directory.
   repeated string excludes = 2;
+  // Ignore all of these header files, because they don't need an explicit
+  // dependency. This is used to ignore c stdlib headers, e.g. string.h.
+  repeated string ignore_headers = 3;
 }

--- a/nrfbazelify/nrfbazelify.go
+++ b/nrfbazelify/nrfbazelify.go
@@ -278,9 +278,21 @@ func (b *buildGen) readIncludes(path string, exclude string) ([]string, error) {
 		if matches[1] == exclude {
 			continue
 		}
+		if b.shouldIgnore(matches[1]) {
+			continue
+		}
 		out = append(out, matches[1])
 	}
 	return out, nil
+}
+
+func (b *buildGen) shouldIgnore(header string) bool {
+	for _, ignore := range b.rc.GetIgnoreHeaders() {
+		if header == ignore {
+			return true
+		}
+	}
+	return false
 }
 
 type targetInfo struct {

--- a/nrfbazelify/nrfbazelify_test.go
+++ b/nrfbazelify/nrfbazelify_test.go
@@ -320,3 +320,21 @@ func TestGenerateBuildFiles_BazelifyRCExcludes(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateBuildFiles_BazelifyRCIgnoreHeaders(t *testing.T) {
+	workspaceDir := mustMakeAbs(t, testDataDir)
+	sdkDir := filepath.Join(workspaceDir, "bazelifyrc_ignore_headers")
+	t.Cleanup(func() {
+		removeAllBuildFiles(t, sdkDir)
+	})
+	if err := GenerateBuildFiles(workspaceDir, sdkDir); err != nil {
+		t.Fatalf("GenerateBuildFiles(%s, %s): %v", testDataDir, sdkDir, err)
+	}
+	checkBuildFiles(t, &buildfile.Library{
+		Dir:      sdkDir,
+		Name:     "a",
+		Hdrs:     []string{"a.h"},
+		Includes: []string{"."},
+	})
+
+}

--- a/nrfbazelify/testdata/bazelifyrc_ignore_headers/.bazelifyrc
+++ b/nrfbazelify/testdata/bazelifyrc_ignore_headers/.bazelifyrc
@@ -1,0 +1,1 @@
+ignore_headers: "string.h"

--- a/nrfbazelify/testdata/bazelifyrc_ignore_headers/a.h
+++ b/nrfbazelify/testdata/bazelifyrc_ignore_headers/a.h
@@ -1,0 +1,1 @@
+#include "string.h"


### PR DESCRIPTION
This lets users ignore certain header files, such as c stdlib files.