### PR TITLE
Improve resolution hint with override safeguards and write to file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,6 +38,7 @@ http_archive(
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
 protobuf_deps()
 
 load("//:repositories.bzl", "nrfbazel_dependencies")

--- a/nrfbazelify/BUILD
+++ b/nrfbazelify/BUILD
@@ -17,5 +17,11 @@ go_test(
     srcs = ["nrfbazelify_test.go"],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
-    deps = ["//internal/buildfile"],
+    deps = [
+        "//bazelifyrc:bazelifyrc_go_proto",
+        "//internal/buildfile",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
+    ],
 )

--- a/nrfbazelify/testdata/bazelifyrc_hint/exists.h
+++ b/nrfbazelify/testdata/bazelifyrc_hint/exists.h
@@ -1,0 +1,1 @@
+#include "doesnotexist.h"

--- a/nrfbazelify/testdata/bazelifyrc_hint_keep_override/.bazelifyrc
+++ b/nrfbazelify/testdata/bazelifyrc_hint_keep_override/.bazelifyrc
@@ -1,0 +1,4 @@
+target_overrides <
+  key: "overridden.h"
+  value: "//something"
+>

--- a/nrfbazelify/testdata/bazelifyrc_hint_keep_override/exists.h
+++ b/nrfbazelify/testdata/bazelifyrc_hint_keep_override/exists.h
@@ -1,0 +1,2 @@
+#include "doesnotexist.h"
+#include "overridden.h"


### PR DESCRIPTION
The original output was very verbose. Instead, we now write to the .bazelifyrc.hint file. This is nicer because it lets the user simply move the file ove, and the stdout of nrfbazelify is a lot smaller (and readable!). In addition, it lets us test the hint output.

Also add a test for resolution hint output.