### PR TITLE
Improve hint by including what requires each unresolved target

### DIFF
--- a/nrfbazelify/nrfbazelify_test.go
+++ b/nrfbazelify/nrfbazelify_test.go
@@ -235,7 +235,7 @@ func TestGenerateBuildFiles_BazelifyRCHint(t *testing.T) {
 	}
 	if diff := cmp.Diff(&bazelifyrc.Configuration{
 		TargetOverrides: map[string]string{
-			"doesnotexist.h": "PLEASE RESOLVE: ",
+			"doesnotexist.h": "REQUIRED BY <SDK>/exists.h PLEASE RESOLVE: ",
 		},
 	}, hint, protocmp.Transform()); diff != "" {
 		t.Fatalf("bazelifyrc hint (-want +got): %s", diff)
@@ -260,7 +260,7 @@ func TestGenerateBuildFiles_BazelifyRCHintKeepOverride(t *testing.T) {
 	if diff := cmp.Diff(&bazelifyrc.Configuration{
 		TargetOverrides: map[string]string{
 			"overridden.h": "//something",
-			"doesnotexist.h": "PLEASE RESOLVE: ",
+			"doesnotexist.h": "REQUIRED BY <SDK>/exists.h PLEASE RESOLVE: ",
 		},
 	}, hint, protocmp.Transform()); diff != "" {
 		t.Fatalf("bazelifyrc hint (-want +got): %s", diff)
@@ -440,7 +440,5 @@ func TestGenerateBuildFiles_BazelifyRCIncludeDirs(t *testing.T) {
 		Name:     "c",
 		Hdrs:     []string{"c.h"},
 		Includes: []string{"."},
-	},
-	)
-
+	})
 }


### PR DESCRIPTION
I added a REQUIRED BY x,y,z in front of the PLEASE RESOLVE message. x,y,z are file names that include this target. In verbose mode, it will print the pretty SDK path, which is relative to the sdk directory. Otherwise, it will print just the file name that includes the target.