### PR TITLE
Return an error if loading .bazelifyrc fails

### DIFF
--- a/nrfbazelify/nrfbazelify.go
+++ b/nrfbazelify/nrfbazelify.go
@@ -61,7 +61,7 @@ type buildGen struct {
 
 func (b *buildGen) generate() error {
 	if err := b.loadBazelifyRC(); err != nil {
-		log.Printf("Not loading .bazelifyrc: %v", err)
+		return fmt.Errorf("not loading .bazelifyrc: %v", err)
 	}
 	if err := filepath.Walk(b.sdkDir, b.buildTargetsMap); err != nil {
 		return fmt.Errorf("filepath.Walk(%s): %v", b.sdkDir, err)
@@ -76,6 +76,10 @@ func (b *buildGen) loadBazelifyRC() error {
 	// We read this file from the root of the SDK, so that we can have
 	// per-SDK overrides in the same workspace.
 	rcPath := filepath.Join(b.sdkDir, rcFilename)
+	if _, err := os.Stat(rcPath); err != nil {
+		log.Printf("WARNING: No .bazelifyrc found: os.Stat: %v", err)
+		return nil
+	}
 	rcData, err := ioutil.ReadFile(rcPath)
 	if err != nil {
 		return fmt.Errorf("Could not read %s: %v", rcFilename, err)

--- a/nrfbazelify/nrfbazelify_test.go
+++ b/nrfbazelify/nrfbazelify_test.go
@@ -442,3 +442,18 @@ func TestGenerateBuildFiles_BazelifyRCIncludeDirs(t *testing.T) {
 		Includes: []string{"."},
 	})
 }
+
+func TestGenerateBuildFiles_BazelifyRCMalformed(t *testing.T) {
+	workspaceDir := mustMakeAbs(t, testDataDir)
+	sdkDir := filepath.Join(workspaceDir, "bazelifyrc_malformed")
+	t.Cleanup(func() {
+		removeAllBuildFiles(t, sdkDir)
+	})
+	if err := GenerateBuildFiles(workspaceDir, sdkDir, true); err == nil {
+		t.Fatalf("GenerateBuildFiles(%s, %s): nil error, want an error", testDataDir, sdkDir)
+	}
+	hintPath := filepath.Join(sdkDir, ".bazelifyrc.hint")
+	if _, err := os.Stat(hintPath); err == nil {
+		t.Fatalf("os.Stat(%s): nil error, want an error", hintPath)
+	}
+}

--- a/nrfbazelify/testdata/bazelifyrc_malformed/.bazelifyrc
+++ b/nrfbazelify/testdata/bazelifyrc_malformed/.bazelifyrc
@@ -1,0 +1,2 @@
+# Note that there is only 1 quotation mark.
+include_dirs: "


### PR DESCRIPTION
I originally skipped .bazelifyrc failures, because it's possible to not have a .bazelifyrc. But, I was also opaquely skipping proto marshalling errors, which led to some confusion. Now, I Stat the file, and print a loud WARNING if there's no file. For other errors, I throw an actual error and exit early, instead of continuing.