### PR TITLE
Assemble whole BUILD files before writing, add visibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,7 @@ go 1.14
 
 require (
 	github.com/golang/protobuf v1.4.2
+	github.com/google/go-cmp v0.4.0
 	golang.org/x/tools v0.0.0-20200702044944-0cc1aa72b347 // indirect
+	google.golang.org/protobuf v1.23.0
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
Our previous implementation appended cc_library rules to the BUILD file, and we didn't have any idea about the whole BUILD file's contents. This caused a few problems:
* We don't have the information to write things like loads and package default visibility.
* We perform a lot of file writes
* Order of the generated BUILD rules wasn't consistent, which would lead to lots of churn between reruns of nrfbazelify.

This fixes all of these problems by first assembling the data into a buildfile.File, before writing out the contents to disk. This may come at the cost of more memory, but shouldn't be significantly more than before.