### PR TITLE
Load cc_library in every build file

### DIFF
--- a/internal/buildfile/buildfile.go
+++ b/internal/buildfile/buildfile.go
@@ -63,6 +63,11 @@ func (f *File) Generate() string {
 	return out
 }
 
+// AddLoad adds a load statement to this file.
+func (f *File) AddLoad(load *Load) {
+	f.loads = append(f.loads, load)
+}
+
 // AddLibrary adds a library to this file.
 func (f *File) AddLibrary(lib *Library) {
 	f.libs = append(f.libs, lib)

--- a/nrfbazelify/nrfbazelify.go
+++ b/nrfbazelify/nrfbazelify.go
@@ -158,6 +158,10 @@ func (b *buildGen) outputFiles() error {
 		return err
 	}
 	files[b.sdkDir] = buildfile.New(b.sdkDir)
+	files[b.sdkDir].AddLoad(&buildfile.Load{
+		Source: "@rules_cc//cc:defs.bzl",
+		Symbols: []string{"cc_library"},
+	})
 	r := remap.New(b.rc.GetRemaps(), sdkFromWorkspace)
 	for _, lib := range r.Libraries() {
 		files[b.sdkDir].AddLibrary(lib)
@@ -189,6 +193,10 @@ func (b *buildGen) outputFiles() error {
 			// Find or create a new BUILD file, and add our library to it.
 			if file := files[target.dir]; file == nil {
 				files[target.dir] = buildfile.New(target.dir)
+				files[target.dir].AddLoad(&buildfile.Load{
+					Source: "@rules_cc//cc:defs.bzl",
+					Symbols: []string{"cc_library"},
+				})
 			}
 			files[target.dir].AddLibrary(&buildfile.Library{
 				Name:     strings.TrimSuffix(target.hdrs[0], ".h"),

--- a/nrfbazelify/nrfbazelify_test.go
+++ b/nrfbazelify/nrfbazelify_test.go
@@ -30,6 +30,10 @@ func mustMakeAbs(t *testing.T, dir string) string {
 
 func newBuildFile(dir string, libs []*buildfile.Library, labelAttrs []*buildfile.LabelAttr) *buildfile.File {
 	out := buildfile.New(dir)
+	out.AddLoad(&buildfile.Load{
+		Source: "@rules_cc//cc:defs.bzl",
+		Symbols: []string{"cc_library"},
+	})
 	for _, lib := range libs {
 		out.AddLibrary(lib)
 	}


### PR DESCRIPTION
cc_library is no longer globally defined, and should be imported from @rules_cc//cc:defs.bzl