### PR TITLE
Label library formats labels into string format

### DIFF
--- a/internal/bazel/BUILD
+++ b/internal/bazel/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["label.go"],
+    importpath = "github.com/Michaelhobo/nrfbazel/internal/bazel",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["label_test.go"],
+    embed = [":go_default_library"],
+)

--- a/internal/bazel/label.go
+++ b/internal/bazel/label.go
@@ -1,0 +1,112 @@
+package bazel
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	labelRegexp = regexp.MustCompile(`^//([\w/]*)(?::(\w+))?$`)
+	relativeLabelRegexp = regexp.MustCompile(`^:(\w+)$`)
+)
+
+func JoinLabelStrings(labels []*Label, separator string) string {
+	var out string
+	for i, label := range labels {
+		if i > 0 {
+			out += separator
+		}
+		out += label.String()
+	}
+	return out
+}
+
+// NewLabel creates a new label.
+func NewLabel(absDir, name, workspaceDir string) (*Label, error) {
+	if !filepath.IsAbs(absDir) {
+		return nil, fmt.Errorf("%q must be an absolute path", absDir)
+	}
+	if !strings.HasPrefix(absDir, workspaceDir) {
+		return nil, fmt.Errorf("%q must be in %q", absDir, workspaceDir)
+	}
+	dir, err := filepath.Rel(workspaceDir, absDir)
+	if err != nil {
+		return nil, fmt.Errorf("filepath.Rel(%q, %q): %v", workspaceDir, absDir, err)
+	}
+	return &Label{
+		dir: dir,
+		name: name,
+	}, nil
+}
+
+func ParseLabel(label string) (*Label, error) {
+	capture := labelRegexp.FindStringSubmatch(label)
+	if capture == nil {
+		return nil, fmt.Errorf("%q does not match %q", label, labelRegexp)
+	}
+	dir := capture[1]
+	name := capture[2]
+	if name == "" {
+		if dir == "" {
+			return nil, fmt.Errorf("%q returned an empty regexp capture", label)
+		}
+		name = filepath.Base(dir)
+	}
+	return &Label{
+		dir: dir,
+		name: name,
+	}, nil
+}
+
+func ParseRelativeLabel(other *Label, label string) (*Label, error) {
+	if other == nil {
+		return nil, fmt.Errorf("other label is nil")
+	}
+	capture := relativeLabelRegexp.FindStringSubmatch(label)
+	if len(capture) == 0 {
+		return ParseLabel(label)
+	}
+	name := capture[1]
+	if name == "" {
+		return nil, fmt.Errorf("%q returned an empty regexp capture", label)
+	}	
+	return &Label{
+		dir: other.dir,
+		name: name,
+	}, nil
+}
+
+// Label is a Bazel BUILD label.
+type Label struct {
+	// Relative dir from 
+	dir string
+	name string
+}
+
+// Name returns the label's name.
+func (l *Label) Name() string {
+	return l.name
+}
+
+// Dir returns the directory the label belongs in.
+func (l *Label) Dir() string {
+	return l.dir
+}
+
+func (l *Label) String() string {
+	out := fmt.Sprintf("//%s", l.dir)
+	if filepath.Base(l.dir) != l.name {
+		out = fmt.Sprintf("%s:%s", out, l.name)
+	}
+	return out
+}
+
+// RelativeTo generates the label string relative to another label.
+func (l *Label) RelativeTo(other *Label) string {
+	if l.dir != other.dir {
+		return l.String()
+	}
+	return fmt.Sprintf(":%s", l.name)
+}

--- a/internal/bazel/label_test.go
+++ b/internal/bazel/label_test.go
@@ -1,0 +1,178 @@
+package bazel
+
+import "testing"
+
+func TestLabel_String(t *testing.T) {
+	tests := map[string]struct{
+		label *Label
+		want string
+	}{
+		"nominal": {
+			label: &Label{
+				dir: "something/out/there",
+				name: "aliens",
+			},
+			want: "//something/out/there:aliens",
+		},
+		"name matches directory": {
+			label: &Label{
+				dir: "something/out/there",
+				name: "there",
+			},
+			want: "//something/out/there",
+		},
+		"no directory": {
+			label: &Label{
+				name: "aliens",
+			},
+			want: "//:aliens",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := test.label.String(); got != test.want {
+				t.Errorf("%v String()=%q, want %q", test.label, got, test.want)
+			}
+		})
+	}
+}
+
+func TestLabel_RelativeTo(t *testing.T) {
+	tests := map[string]struct{
+		label *Label
+		other *Label
+		want string
+	}{
+		"same directory": {
+			label: &Label{
+				dir: "something/out/there",
+				name: "aliens",
+			},
+			other: &Label{
+				dir: "something/out/there",
+				name: "stars",
+			},
+			want: ":aliens",
+		},
+		"different directory": {
+			label: &Label{
+				dir: "something/out/there",
+				name: "aliens",
+			},
+			other: &Label{
+				dir: "on/earth",
+				name: "humans",
+			},
+			want: "//something/out/there:aliens",
+		},
+		"no directory": {
+			label: &Label{
+				name: "aliens",
+			},
+			other: &Label{
+				name: "humans",
+			},
+			want: ":aliens",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := test.label.RelativeTo(test.other); got != test.want {
+				t.Errorf("%v RelativeTo(%v)=%q, want %q", test.label, test.other, got, test.want)
+			}
+		})
+	}
+}
+
+func TestLabel_ParseLabel(t *testing.T) {
+	tests := map[string]struct{
+		label string
+		want *Label
+	}{
+		"nominal": {
+			label: "//something/out/there:aliens",
+			want: &Label{
+				dir: "something/out/there",
+				name: "aliens",
+			},
+		},
+		"name matches directory": {
+			label: "//something/out/there",
+			want: &Label{
+				dir: "something/out/there",
+				name: "there",
+			},
+		},
+		"no directory": {
+			label: "//:aliens",
+			want: &Label{
+				name: "aliens",
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseLabel(test.label)
+			if err != nil {
+				t.Errorf("ParseLabel(%q): %v", test.label, err)
+				return
+			}
+			if got.String() != test.want.String() {
+				t.Errorf("ParseLabel(%q)=%q, want %q", test.label, got, test.want)
+			}
+		})
+	}
+
+}
+
+func TestLabel_ParseRelativeLabel(t *testing.T) {
+	tests := map[string]struct{
+		label string
+		other *Label
+		want *Label
+	}{
+		"same directory": {
+			label: ":aliens",
+			other: &Label{
+				dir: "something/out/there",
+				name: "stars",
+			},
+			want: &Label{
+				dir: "something/out/there",
+				name: "aliens",
+			},
+		},
+		"different directory": {
+			label: "//something/out/there:aliens",
+			other: &Label{
+				dir: "on/earth",
+				name: "humans",
+			},
+			want: &Label{
+				dir: "something/out/there",
+				name: "aliens",
+			},
+		},
+		"no directory": {
+			label: ":aliens",
+			other: &Label{
+				name: "humans",
+			},
+			want: &Label{
+				name: "aliens",
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseRelativeLabel(test.other, test.label)
+			if err != nil {
+				t.Errorf("ParseRelativeLabel(%q, %q): %v", test.other, test.label, err)
+				return
+			}
+			if got.String() != test.want.String() {
+				t.Errorf("ParseRelativeLabel(%q, %q)=%q, want %q", test.other, test.label, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This lets us represent a rule as both relative and absolute labels.