### PR TITLE
Turn srcs/hdrs into labels, export group srcs/hdrs

### DIFF
--- a/internal/bazel/label.go
+++ b/internal/bazel/label.go
@@ -110,3 +110,14 @@ func (l *Label) RelativeTo(other *Label) string {
   }
   return fmt.Sprintf(":%s", l.name)
 }
+
+// FileRelativeTo generates the label string as if it's a file.
+// Files in the same dir just have the name, like "some_file.h".
+// Files in different directories should look like a regular label,
+// like "//some/path:some_file.h".
+func (l *Label) FileRelativeTo(dir string) string {
+  if l.dir != dir {
+    return l.String()
+  }
+  return l.name
+}


### PR DESCRIPTION
Group nodes have srcs/hdrs that reference fiels in other subpackages.
We need to specify these files as labels (e.g. //abc:file.h). Convert
all srcs/hdrs to bazel.Label type, and use it to generate the output
label. We also need to export these files from the original subpackage.
I added exports_files to the buildfile library.