### PR TITLE
Print out basic graph stats after successful runs

### DIFF
--- a/nrfbazelify/BUILD
+++ b/nrfbazelify/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config.go",
         "graph.go",
+        "graphstats.go",
         "groups.go",
         "hint.go",
         "nodes.go",

--- a/nrfbazelify/graph.go
+++ b/nrfbazelify/graph.go
@@ -1,17 +1,17 @@
 package nrfbazelify
 
 import (
-  "fmt"
-  "log"
-  "os"
-  "path/filepath"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
 
-  "github.com/Michaelhobo/nrfbazel/internal/bazel"
-  "github.com/Michaelhobo/nrfbazel/internal/buildfile"
-  "github.com/google/uuid"
-  "gonum.org/v1/gonum/graph"
-  "gonum.org/v1/gonum/graph/encoding/dot"
-  "gonum.org/v1/gonum/graph/simple"
+	"github.com/Michaelhobo/nrfbazel/internal/bazel"
+	"github.com/Michaelhobo/nrfbazel/internal/buildfile"
+	"github.com/google/uuid"
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding/dot"
+	"gonum.org/v1/gonum/graph/simple"
 )
 
 // NewDependencyGraph creates a new DependencyGraph.
@@ -59,6 +59,17 @@ func (d *DependencyGraph) outputDOTGraphProgress() error {
   return d.OutputDOTGraph(file)
 }
 
+// StatsSnapshot generates GraphStats based on the current state of this graph.
+func (d *DependencyGraph) StatsSnapshot() *GraphStats {
+  nodes := d.graph.Nodes()
+  edges := d.graph.Edges()
+  return &GraphStats{
+    NodeCount: nodes.Len(),
+    EdgeCount: edges.Len(),
+  }
+}
+
+// Nodes returns a all current nodes.
 func (d *DependencyGraph) Nodes() []Node {
   var out []Node
   nodes := d.graph.Nodes()

--- a/nrfbazelify/graphstats.go
+++ b/nrfbazelify/graphstats.go
@@ -1,0 +1,25 @@
+package nrfbazelify
+
+import (
+	"bytes"
+	"text/template"
+)
+
+var reportTemplate = template.Must(template.New("report").Parse(`Graph stats:
+  Node count: {{ .NodeCount }}
+  Edge count: {{ .EdgeCount }}
+`))
+
+// GraphStats contains stats about the dependency graph.
+// It can be used to generate a report.
+type GraphStats struct {
+  NodeCount int
+  EdgeCount int
+}
+
+// Generates a human-readable report of the graph stats.
+func (g *GraphStats) GenerateReport() string {
+  var out bytes.Buffer
+  reportTemplate.Execute(&out, g)
+  return out.String()
+}

--- a/nrfbazelify/nrfbazelify.go
+++ b/nrfbazelify/nrfbazelify.go
@@ -32,7 +32,6 @@ func GenerateBuildFiles(workspaceDir, sdkDir string, verbose bool) error {
   if err != nil {
     return fmt.Errorf("ReadBazelifyRC: %v", err)
   }
-  log.Printf("Generating BUILD files for %s", sdkDir)
   graph := NewDependencyGraph(sdkDir, workspaceDir, *dotGraphProgressionDir)
   if *dotGraphPath != "" {
     defer func(path string) {
@@ -53,18 +52,22 @@ func GenerateBuildFiles(workspaceDir, sdkDir string, verbose bool) error {
   if len(unresolvedDeps) > 0 {
     return WriteUnresolvedDepsHint(conf, unresolvedDeps)
   }
-	unnamedGroups, err := NameGroups(conf, graph)
-	if err != nil {
-		return fmt.Errorf("NameGroups: %v", err)
-	}
-	if len(unnamedGroups) > 0 {
-		return WriteUnnamedGroupsHint(conf, unnamedGroups)
-	}
+  unnamedGroups, err := NameGroups(conf, graph)
+  if err != nil {
+    return fmt.Errorf("NameGroups: %v", err)
+  }
+  if len(unnamedGroups) > 0 {
+    return WriteUnnamedGroupsHint(conf, unnamedGroups)
+  }
   if err := OutputBuildFiles(conf, graph); err != nil {
     return fmt.Errorf("OutputBuildFiles: %v", err)
   }
   if err := RemoveStaleHint(sdkDir); err != nil {
     return fmt.Errorf("removeStaleHintFile: %v", err)
   }
+
+  stats := graph.StatsSnapshot()
+  log.Print(stats.GenerateReport())
+
   return nil
 }


### PR DESCRIPTION
This is used to help understand the system and to debug.
For example, this made it clear that the graph isn't deterministic,
since the edge count changes between runs.