### PR TITLE
Add chosen group node into node IDs list

### DIFF
--- a/nrfbazelify/graph.go
+++ b/nrfbazelify/graph.go
@@ -331,6 +331,7 @@ func (d *DependencyGraph) mergeCycle(cyclicEdges []graph.Edge) error {
       return fmt.Errorf("AddGroupNode: %v", err)
     }
     groupNode = node
+    nodeIDs[groupNode.ID()] = true
   }
 
   for nodeID := range nodeIDs {


### PR DESCRIPTION
This isn't technically required given the algorithm implementation,
since the chosen group node gets skipped anyway. But, this seems more
like an accident than intentional. Just add it to nodeIDs anyway.