### PR TITLE
Fix one source of non-deterministic cyclic merges

### DIFF
--- a/nrfbazelify/graph.go
+++ b/nrfbazelify/graph.go
@@ -364,7 +364,7 @@ func (d *DependencyGraph) mergeCycle(cyclicEdges []graph.Edge) error {
       return fmt.Errorf("groupNode.Absorb(%q): %v", node.Label(), err)
     }
 
-    // Repoint all edges from and to the node to the group node.
+    // Repoint all edges from the node to the group node.
     fromNodes := d.graph.From(nodeID)
     for fromNodes.Next() {
       d.graph.RemoveEdge(nodeID, fromNodes.Node().ID())
@@ -372,14 +372,6 @@ func (d *DependencyGraph) mergeCycle(cyclicEdges []graph.Edge) error {
         continue
       }
       d.graph.SetEdge(d.graph.NewEdge(groupNode, fromNodes.Node()))
-    }
-    toNodes := d.graph.To(nodeID)
-    for toNodes.Next() {
-      d.graph.RemoveEdge(toNodes.Node().ID(), nodeID)
-      if toNodes.Node().ID() == groupNode.ID() {
-        continue
-      }
-      d.graph.SetEdge(d.graph.NewEdge(toNodes.Node(), groupNode))
     }
   }
 

--- a/nrfbazelify/nrfbazelify_test.go
+++ b/nrfbazelify/nrfbazelify_test.go
@@ -1,19 +1,19 @@
 package nrfbazelify
 
 import (
-	"flag"
-	"fmt"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"testing"
+  "flag"
+  "fmt"
+  "os"
+  "path/filepath"
+  "regexp"
+  "strings"
+  "testing"
 
-	"github.com/Michaelhobo/nrfbazel/internal/buildfile"
-	"github.com/Michaelhobo/nrfbazel/proto/bazelifyrc"
-	"github.com/google/go-cmp/cmp"
-	"google.golang.org/protobuf/encoding/prototext"
-	"google.golang.org/protobuf/testing/protocmp"
+  "github.com/Michaelhobo/nrfbazel/internal/buildfile"
+  "github.com/Michaelhobo/nrfbazel/proto/bazelifyrc"
+  "github.com/google/go-cmp/cmp"
+  "google.golang.org/protobuf/encoding/prototext"
+  "google.golang.org/protobuf/testing/protocmp"
 )
 
 var testDataDir = "testdata"
@@ -646,7 +646,7 @@ func TestGenerateBuildFiles_CyclesNominal(t *testing.T) {
         Name: "uses_cyclic",
         Hdrs: []string{"uses_cyclic.h"},
         Includes: []string{"cycles_nominal/dir"},
-        Deps: []string{"//cycles_nominal:abcd"},
+        Deps: []string{":c"},
       },
       {
         Name: "c",


### PR DESCRIPTION
When merging, we were taking all things that depended on all nodes in
the cycle, and pointing them all to the group node. Instead, we should
maintain those deps on the original nodes.

Tested by running all tests 20 times.
The tests used to fail every few times.