### PR TITLE
Switch remap templates to text/template

### DIFF
--- a/example/BUILD
+++ b/example/BUILD
@@ -20,10 +20,10 @@ cc_library(
         "//example/dir:c.h",
         "//example/dir2:d.h",
     ],
-    includes = [
-        "example",
-        "example/dir",
-        "example/dir2",
+    copts = [
+        "-Iexample",
+        "-Iexample/dir",
+        "-Iexample/dir2",
     ],
     deps = ["//example/dir2:used_by_cyclic"],
 )
@@ -33,7 +33,6 @@ cc_library(name = "nrfbazelify_empty_remap")
 cc_library(
     name = "sdk_config",
     hdrs = ["sdk_config.h"],
-    includes = ["example"],
 )
 
 label_setting(

--- a/example/dir/BUILD
+++ b/example/dir/BUILD
@@ -12,6 +12,6 @@ cc_library(
 cc_library(
     name = "uses_cyclic",
     hdrs = ["uses_cyclic.h"],
-    includes = ["example/dir"],
+    copts = ["-Iexample/dir"],
     deps = [":c"],
 )

--- a/example/dir2/BUILD
+++ b/example/dir2/BUILD
@@ -12,5 +12,4 @@ cc_library(
 cc_library(
     name = "used_by_cyclic",
     hdrs = ["used_by_cyclic.h"],
-    includes = ["example/dir2"],
 )


### PR DESCRIPTION
text/template is a lot easier to read, compared to multiple Sprintf blocks appended together.